### PR TITLE
Use the name of the referenced schema when parsing references

### DIFF
--- a/lib/swagger/attachable.rb
+++ b/lib/swagger/attachable.rb
@@ -16,14 +16,14 @@ module Swagger
 
     # @api private
     def attach_to_children
-      each_value do |v| # rubocop:disable Style/Next
+      each_value do |v|
         v.attach_parent self if v.respond_to? :attach_parent
         if v.respond_to? :each_value
           v.each_value do |sv|
             sv.attach_parent self if sv.respond_to? :attach_parent
           end
         end
-        if v.respond_to? :each
+        if v.respond_to? :each # rubocop:disable Style/Next
           v.each do |sv|
             sv.attach_parent self if sv.respond_to? :attach_parent
           end

--- a/lib/swagger/builder.rb
+++ b/lib/swagger/builder.rb
@@ -38,7 +38,7 @@ module Swagger
         dash.instance_variable_set(property, coercions)
       end
 
-      def [](key, &_block)
+      def [](key, &_block) # rubocop:disable Lint/NestedMethodDefinition
         super(key) do |v|
           if block_given?
             v ||= send(:[]=, key, {})
@@ -77,7 +77,7 @@ module Swagger
                         # include is public in Ruby 2.1+, hack to support older
                         bash_klass.send(:include, Bash)
                       end
-      ) unless klass.const_defined? 'Bash'
+                     ) unless klass.const_defined? 'Bash'
 
       klass.const_get('Bash')
     end

--- a/lib/swagger/mime_type.rb
+++ b/lib/swagger/mime_type.rb
@@ -7,7 +7,7 @@ module Swagger
     extend Forwardable
     def_delegators :@mime_type, :media_type, :sub_type
 
-    MIME_TYPE_FORMAT = /(\w+)\/(\w+\.)?([\w\.]+)(\+\w+)?\s*(;.*)?/
+    MIME_TYPE_FORMAT = %r{(\w+)/(\w+\.)?([\w\.]+)(\+\w+)?\s*(;.*)?}
 
     COMMON_ALIASES = {
       txt:    'text/plain',

--- a/lib/swagger/schema.rb
+++ b/lib/swagger/schema.rb
@@ -21,12 +21,7 @@ module Swagger
         schema.merge!(model)
       end
 
-      count = 0
-      until schema.refs_resolved?
-        fail 'Could not resolve non-remote $refs 5 cycles - circular references?' if count >= 5
-        schema.resolve_refs
-        count += 1
-      end
+      schema.resolve_all_refs(schema)
 
       schema.to_hash
     end
@@ -35,6 +30,15 @@ module Swagger
 
     def refs
       deep_find_all('$ref')
+    end
+
+    def resolve_all_refs(schema)
+      count = 0
+      until schema.refs_resolved?
+        fail 'Could not resolve non-remote $refs 5 cycles - circular references?' if count >= 5
+        schema.resolve_refs
+        count += 1
+      end
     end
 
     def resolve_refs

--- a/lib/swagger/schema.rb
+++ b/lib/swagger/schema.rb
@@ -16,7 +16,7 @@ module Swagger
     def parse
       schema = clone
       if schema.key?('$ref')
-        key = schema.delete('$ref')
+        key = schema.delete('$ref').split('/').last
         model = root.definitions[key]
         schema.merge!(model)
       end

--- a/lib/swagger/schema.rb
+++ b/lib/swagger/schema.rb
@@ -23,7 +23,7 @@ module Swagger
 
       schema.resolve_all_refs(schema)
 
-      schema.to_hash
+      schema
     end
 
     protected

--- a/swagger-core.gemspec
+++ b/swagger-core.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |spec|
   spec.license       = 'Apache-2.0'
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(/^bin\//) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
   spec.add_dependency 'addressable', '~> 2.3'


### PR DESCRIPTION
Previously, the full path was used, i.e. $/Definitions/User
Since root.definitions only stores the name (User), parsing references
would always fail.
